### PR TITLE
Make BitmarkdRPCClient be able to connect to multiple persistent clients.

### DIFF
--- a/client.go
+++ b/client.go
@@ -40,7 +40,7 @@ func NewPersistentRPCClient(address string, timeout time.Duration) *PersistentRP
 	}
 }
 
-// Call is to make an RPC request. It will whether the connection is still alived.
+// Call is to make an RPC request. It will check whether the connection is still alive.
 // If not, it will try to create one.
 func (c *PersistentRPCClient) Call(serviceMethod string, args interface{}, reply interface{}) error {
 	client, err := c.client()

--- a/client.go
+++ b/client.go
@@ -24,7 +24,7 @@ type RPCEmptyArguments struct{}
 
 // PersistentRPCClient is client that will maintain a long-lived connection for requests
 type PersistentRPCClient struct {
-	sync.RWMutex
+	sync.Mutex
 	*rpc.Client
 	address   string
 	closed    chan struct{}
@@ -49,8 +49,6 @@ func (c *PersistentRPCClient) Call(serviceMethod string, args interface{}, reply
 		}
 	}
 
-	c.RLock()
-	defer c.RUnlock()
 	if !c.connected {
 		return ErrRPCConnectionClosed
 	}

--- a/client.go
+++ b/client.go
@@ -7,83 +7,155 @@ package bitmarkdClient
 import (
 	"crypto/tls"
 	"fmt"
+	"net"
 	"net/rpc"
 	"net/rpc/jsonrpc"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
-// ErrRPCConnection is an error for rpc connection
-var ErrRPCConnection = fmt.Errorf("can not connect to rpc server")
+var ErrRPCRequestTimeout = fmt.Errorf("rpc requests timed out")
+var ErrRPCConnectionClosed = fmt.Errorf("rpc connection closed")
+var ErrCannotEstablishConnection = fmt.Errorf("connection can not be established")
 
 // RPCEmptyArguments is an empty argument for rpc requests
 type RPCEmptyArguments struct{}
 
-// BitmarkdRPCClient is a struct for bitmarkd
-type BitmarkdRPCClient struct {
-	sync.Mutex
-	client     *rpc.Client
-	address    string
-	connected  bool
-	retryTimes uint
+// PersistentRPCClient is client that will maintain a long-lived connection for requests
+type PersistentRPCClient struct {
+	sync.RWMutex
+	*rpc.Client
+	address   string
+	closed    chan struct{}
+	connected bool
+	timeout   time.Duration
 }
 
-// NewBitmarkdRPCClient is to create a rpc client for bitmarkd
-func New(address string) *BitmarkdRPCClient {
-	client := &BitmarkdRPCClient{
-		address:    address,
-		retryTimes: 3,
+func NewPersistentRPCClient(address string, timeout time.Duration) *PersistentRPCClient {
+	return &PersistentRPCClient{
+		address: address,
+		timeout: timeout,
+		closed:  make(chan struct{}),
 	}
-	return client
 }
 
-// Connect will establish rpc connection over tls
-func (bc *BitmarkdRPCClient) Connect() error {
-	bc.Lock()
-	defer bc.Unlock()
-	conn, err := tls.Dial("tcp", bc.address, &tls.Config{
+// Call is to make an RPC request. It will whether the connection is still alived.
+// If not, it will try to create one.
+func (c *PersistentRPCClient) Call(serviceMethod string, args interface{}, reply interface{}) error {
+	if !c.connected {
+		if err := c.connect(); err != nil {
+			return ErrCannotEstablishConnection
+		}
+	}
+
+	c.RLock()
+	defer c.RUnlock()
+	if !c.connected {
+		return ErrRPCConnectionClosed
+	}
+
+	select {
+	case call := <-c.Client.Go(serviceMethod, args, reply, make(chan *rpc.Call, 1)).Done:
+		return call.Error
+	case <-c.closed:
+		return ErrRPCConnectionClosed
+	case <-time.After(c.timeout):
+		return ErrRPCRequestTimeout
+	}
+}
+
+// Close will close the current connection
+func (c *PersistentRPCClient) Close() error {
+	c.Lock()
+	defer c.Unlock()
+
+	if !c.connected {
+		return nil
+	}
+
+	c.connected = false
+	close(c.closed)
+	return c.Client.Close()
+}
+
+// connect will establish a TCP connection to the remote
+func (c *PersistentRPCClient) connect() error {
+	c.Lock()
+	defer c.Unlock()
+
+	if c.connected {
+		return nil
+	}
+
+	conn, err := tls.Dial("tcp", c.address, &tls.Config{
 		InsecureSkipVerify: true,
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("can not dial to: %s, error: %s", c.address, err.Error())
 	}
-	bc.client = jsonrpc.NewClient(conn)
-	bc.connected = true
+	c.connected = true
+	c.closed = make(chan struct{})
+	c.Client = jsonrpc.NewClient(conn)
 	return nil
 }
 
-// Close will terminate the rpc connection
-func (bc *BitmarkdRPCClient) Close() {
-	bc.client.Close()
-	bc.connected = false
+// BitmarkdRPCClient is a client to make bitmarkd RPC requests. It maintains
+// a list of PersistentRPCClient that will create connections to bitmarkd.
+type BitmarkdRPCClient struct {
+	sync.RWMutex
+	counter   uint32
+	clients   map[string]*PersistentRPCClient
+	addresses []string
 }
 
-func (bc *BitmarkdRPCClient) call(command string, args interface{}, reply interface{}) error {
-	if bc.client == nil {
-		err := bc.Connect()
-		if err != nil {
-			return ErrRPCConnection
-		}
+// NewBitmarkdRPCClient is to create a rpc client for bitmarkd
+func New(addresses []string, timeout time.Duration) *BitmarkdRPCClient {
+	clients := map[string]*PersistentRPCClient{}
+
+	for _, addr := range addresses {
+		clients[addr] = NewPersistentRPCClient(addr, timeout)
 	}
 
-	var err error
-	for i := bc.retryTimes; i > 0; i-- {
-		err = bc.client.Call(command, args, reply)
+	client := &BitmarkdRPCClient{
+		addresses: addresses,
+		clients:   clients,
+	}
 
-		if err != nil {
-			if err == rpc.ErrShutdown {
-				time.Sleep(time.Second)
-				bc.connected = false
-				bc.Connect()
-				continue
-			}
+	return client
+}
+
+// Close will terminate all rpc clients
+func (bc *BitmarkdRPCClient) Close() {
+	bc.Lock()
+	defer bc.Unlock()
+	for _, c := range bc.clients {
+		c.Close()
+	}
+}
+
+// client will return a client based on the addresses list in a round-robin manner
+func (bc *BitmarkdRPCClient) client() *PersistentRPCClient {
+	bc.RLock()
+	defer bc.RUnlock()
+	counter := atomic.AddUint32(&bc.counter, 1)
+	index := int(counter) % len(bc.addresses)
+	addr := bc.addresses[index]
+	return bc.clients[addr]
+}
+
+// call will first get a rpc client by `client` function and use that client to request an RPC
+func (bc *BitmarkdRPCClient) call(command string, args interface{}, reply interface{}) error {
+	client := bc.client()
+	err := client.Call(command, args, reply)
+	if err != nil {
+		if _, ok := err.(*net.OpError); ok {
+			client.Close()
 		}
-		return err
+
+		if err == rpc.ErrShutdown {
+			client.Close()
+		}
 	}
 	return err
-}
-
-// Address returns the ip address of the rpc server
-func (bc *BitmarkdRPCClient) Address() string {
-	return bc.address
 }

--- a/client_test.go
+++ b/client_test.go
@@ -111,7 +111,7 @@ func TestPersistentRPCClientConnectClosed(t *testing.T) {
 	var reply TestReply
 
 	go func() {
-		time.Sleep(0)
+		time.Sleep(10 * time.Millisecond)
 		c.Close()
 	}()
 

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,135 @@
+package bitmarkdClient
+
+import (
+	"crypto/rand"
+	"crypto/tls"
+	"fmt"
+	"net/rpc"
+	"net/rpc/jsonrpc"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type TestReply struct {
+	OK int
+}
+
+type Dummy struct{}
+
+func (d *Dummy) Test(args *RPCEmptyArguments, reply *TestReply) error {
+	reply.OK = 1
+	return nil
+}
+
+func (d *Dummy) Sleep(args *RPCEmptyArguments, reply *TestReply) error {
+	time.Sleep(5 * time.Second)
+	reply.OK = 1
+	return nil
+}
+
+type Node struct {
+	IP string
+}
+type TestNodeReply struct {
+	IP string
+}
+
+func (n *Node) Info(args *RPCEmptyArguments, reply *TestNodeReply) error {
+	reply.IP = n.IP
+	return nil
+}
+
+func mockRPCServer(port string, handler interface{}) error {
+	server := rpc.NewServer()
+	err := server.Register(handler)
+	if err != nil {
+		return fmt.Errorf("Format of service Dummy isn't correct. %s", err)
+	}
+
+	cert, err := tls.LoadX509KeyPair("test-certs/server.pem", "test-certs/server.key")
+	if err != nil {
+		return fmt.Errorf("server: loadkeys: %s", err)
+	}
+	config := tls.Config{Certificates: []tls.Certificate{cert}, InsecureSkipVerify: true}
+	config.Rand = rand.Reader
+
+	l, err := tls.Listen("tcp", ":"+port, &config)
+	if err != nil {
+		return fmt.Errorf("Couldn't start listening on port 1234. Error %s", err)
+	}
+
+	go func() {
+		conn, err := l.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		server.ServeCodec(jsonrpc.NewServerCodec(conn))
+	}()
+	return nil
+}
+
+func TestPersistentRPCClientRequestSuccessfully(t *testing.T) {
+	assert.NoError(t, mockRPCServer("12345", new(Dummy)))
+
+	c := NewPersistentRPCClient("127.0.0.1:12345", 10*time.Second)
+	args := RPCEmptyArguments{}
+	var reply TestReply
+
+	err := c.Call("Dummy.Test", args, &reply)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 1, reply.OK)
+}
+
+func TestPersistentRPCClientConnectFailure(t *testing.T) {
+	c := NewPersistentRPCClient("127.0.0.1:12346", time.Second)
+	args := RPCEmptyArguments{}
+	var reply TestReply
+
+	err := c.Call("Dummy.Test", args, &reply)
+	assert.EqualError(t, err, `connection can not be established`)
+}
+
+func TestPersistentRPCClientConnectTimeout(t *testing.T) {
+	assert.NoError(t, mockRPCServer("12347", new(Dummy)))
+
+	c := NewPersistentRPCClient("127.0.0.1:12347", time.Millisecond)
+	args := RPCEmptyArguments{}
+	var reply TestReply
+
+	err := c.Call("Dummy.Sleep", args, &reply)
+	assert.EqualError(t, err, ErrRPCRequestTimeout.Error())
+}
+
+func TestPersistentRPCClientConnectClosed(t *testing.T) {
+	assert.NoError(t, mockRPCServer("12348", new(Dummy)))
+
+	c := NewPersistentRPCClient("127.0.0.1:12348", 5*time.Second)
+	args := RPCEmptyArguments{}
+	var reply TestReply
+
+	go func() {
+		time.Sleep(0)
+		c.Close()
+	}()
+
+	err := c.Call("Dummy.Sleep", args, &reply)
+	assert.EqualError(t, err, ErrRPCConnectionClosed.Error())
+}
+
+func TestBitmarkdRPCClientDummyNodeInfo(t *testing.T) {
+	assert.NoError(t, mockRPCServer("23456", &Node{IP: "localhost:23456"}))
+	assert.NoError(t, mockRPCServer("23457", &Node{IP: "localhost:23457"}))
+
+	c := New([]string{"127.0.0.1:23456", "127.0.0.1:23457"}, 5*time.Second)
+
+	data, err := c.GetNodeInfo()
+	assert.NoError(t, err)
+	assert.Equal(t, `{"IP":"localhost:23457"}`, string(data))
+
+	data, err = c.GetNodeInfo()
+	assert.NoError(t, err)
+	assert.Equal(t, `{"IP":"localhost:23456"}`, string(data))
+}

--- a/common_test.go
+++ b/common_test.go
@@ -1,0 +1,33 @@
+package bitmarkdClient
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func setup() error {
+	if err := os.Mkdir("test-certs", 0755); err != nil {
+		return err
+	}
+
+	cmd := exec.Command("openssl",
+		"req", "-new", "-nodes", "-x509", "-out", "test-certs/server.pem", "-keyout", "test-certs/server.key",
+		"-days", "3650", "-subj", "/C=TW/ST=TPE/L=Earth/O=Bitmark Inc/OU=IT/CN=www.bitmark.com/emailAddress=test@bitmark.com")
+	return cmd.Run()
+}
+
+func tearDown() {
+	os.RemoveAll("test-certs")
+}
+
+func TestMain(m *testing.M) {
+	err := setup()
+	if err != nil {
+		fmt.Println(err)
+	}
+	r := m.Run()
+	tearDown()
+	os.Exit(r)
+}

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.12
 require (
 	github.com/bitmark-inc/bitmark-sdk-go v0.2.0
 	github.com/bitmark-inc/bitmarkd v0.10.7
+	github.com/stretchr/testify v1.2.2
 )

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/lemonlatte/bitmarkdClient
+
+go 1.12
+
+require (
+	github.com/bitmark-inc/bitmark-sdk-go v0.2.0
+	github.com/bitmark-inc/bitmarkd v0.10.7
+)


### PR DESCRIPTION
In this PR, we make the following changes:

- Create a connection pool mechanism so that clients will be selected in the round-robin manner
- Make each clients be able to maintain its own connections
